### PR TITLE
Add in batch updates via onChangeUrlQueryParams #5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
 script:
   - npm run check:src
   - npm run build
-  - npm run check:examples
 branches:
   only:
     - master

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -27,6 +27,8 @@
     * [pushInUrlQuery](/docs/api/pushInUrlQuery.md)
     * [replaceUrlQuery](/docs/api/replaceUrlQuery.md)
     * [pushUrlQuery](/docs/api/pushUrlQuery.md)
+    * [multiReplaceInUrlQuery](/docs/api/multiReplaceInUrlQuery.md)
+    * [multiPushInUrlQuery](/docs/api/multiPushInUrlQuery.md)
 
   * React Router v4
     * [RouterToUrlQuery](/docs/api/RouterToUrlQuery.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -25,6 +25,8 @@ React URL Query provides a number of top-level exports.
 * [pushInUrlQuery(queryParam, encodedValue, [location])](pushInUrlQuery.md)
 * [replaceUrlQuery(newQuery, [location])](replaceUrlQuery.md)
 * [pushUrlQuery(newQuery, [location])](pushUrlQuery.md)
+* [multiReplaceInUrlQuery(queryReplacements, [location])](multiReplaceInUrlQuery.md)
+* [multiPushInUrlQuery(queryReplacements, [location])](multiPushInUrlQuery.md)
 
 #### React-Router v4
 * [RouterToUrlQuery](RouterToUrlQuery.md)

--- a/docs/api/addUrlProps.md
+++ b/docs/api/addUrlProps.md
@@ -4,7 +4,7 @@ Higher order component that injects URL query parameters as props in the wrapped
 
 * `urlPropsQueryConfig` (*Object*): The `urlPropsQueryConfig` object, [see below for details](#urlPropsQueryConfig). Most commonly this is the only option configured.
 
-* `addUrlChangeHandlers` (*Boolean*): If true and a `urlPropsQueryConfig` object is provided, change handler functions will be generated for each configured query parameter. If not provided, it uses whatever was configured in [`configureUrlQuery`](configureUrlQuery.md).
+* `addUrlChangeHandlers` (*Boolean*): If true and a `urlPropsQueryConfig` object is provided, change handler functions will be generated for each configured query parameter. It will also add a special handler `onChangeUrlQueryParams()` for updating multiple parameters at once (pass an object mapping prop names to their new (unencoded) values). If not provided, it uses whatever was configured in [`configureUrlQuery`](configureUrlQuery.md).
 
 * `changeHandlerName` (*Function*): Specifies how change handler names are generated when `addUrlChangeHandlers` is set to `true`. By default, maps `propName` to `onChangePropName`. If not provided, it uses whatever was configured in [`configureUrlQuery`](configureUrlQuery.md).
 

--- a/docs/api/multiPushInUrlQuery.md
+++ b/docs/api/multiPushInUrlQuery.md
@@ -1,0 +1,29 @@
+### `multiPushInUrlQuery(queryReplacements, [location])`
+
+Updates the URL to have the specified query parameter's values set to those in the `queryReplacements` object, while keeping all the other query parameters the same. The `queryReplacements` object has the form:
+
+```
+{
+  queryParamName: encodedValue,
+  ...
+}
+```
+
+Uses push to change the URL, which means the new state will be pushed on to the history stack, so the back button will be able to return you to the previous state.
+
+#### Arguments
+
+1. `queryReplacements` (*String*): The object representing the query parameters and their encoded values to update.
+1. [`location`] (*Object*): The location from which the current URL state should be read. If not provided, `location` is read from the configured `history` or the `window`.
+
+#### Returns
+
+(*Any*): The result of `history.push()`, will depend on the history being used.
+
+#### Examples
+
+```js
+// Given URL /page?foo=bar&baz=123&jim=bo
+multiPushInUrlQuery({ foo: 'test', baz: '99' });
+// URL is now /page?foo=test&baz=99&jim=bo
+```

--- a/docs/api/multiReplaceInUrlQuery.md
+++ b/docs/api/multiReplaceInUrlQuery.md
@@ -1,0 +1,29 @@
+### `multiReplaceInUrlQuery(queryReplacements, [location])`
+
+Updates the URL to have the specified query parameter's values set to those in the `queryReplacements` object, while keeping all the other query parameters the same. The `queryReplacements` object has the form:
+
+```
+{
+  queryParamName: encodedValue,
+  ...
+}
+```
+
+Uses replace to change the URL, which means nothing gets pushed on to the history stack, so the back button will not be able to return you to the previous state.
+
+#### Arguments
+
+1. `queryReplacements` (*String*): The object representing the query parameters and their encoded values to update.
+1. [`location`] (*Object*): The location from which the current URL state should be read. If not provided, `location` is read from the configured `history` or the `window`.
+
+#### Returns
+
+(*Any*): The result of `history.replace()`, will depend on the history being used.
+
+#### Examples
+
+```js
+// Given URL /page?foo=bar&baz=123&jim=bo
+multiReplaceInUrlQuery({ foo: 'test', baz: '99' });
+// URL is now /page?foo=test&baz=99&jim=bo
+```

--- a/examples/basic/src/MainPage.js
+++ b/examples/basic/src/MainPage.js
@@ -22,6 +22,7 @@ class MainPage extends PureComponent {
     // updating that single query parameter and keeping the other existing ones.
     onChangeFoo: PropTypes.func,
     onChangeBar: PropTypes.func,
+    onChangeUrlQueryParams: PropTypes.func,
   }
 
   static defaultProps = {
@@ -30,8 +31,10 @@ class MainPage extends PureComponent {
   }
 
   render() {
-    const { foo, bar, onChangeFoo, onChangeBar } = this.props;
-
+    const {
+      foo, bar, onChangeFoo, onChangeBar, onChangeUrlQueryParams
+    } = this.props;
+    console.log('RENDER', foo, bar);
     return (
       <div>
         <table>
@@ -53,6 +56,16 @@ class MainPage extends PureComponent {
               <td>
                 <button onClick={() => onChangeBar(Math.random().toString(32).substring(8))}>
                   Change bar
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td colSpan={4}>
+                <button onClick={() => onChangeUrlQueryParams({
+                  foo: Math.round(Math.random() * 1000),
+                  bar: Math.random().toString(32).substring(8),
+                })}>
+                  Change both with one URL update
                 </button>
               </td>
             </tr>

--- a/examples/basic/src/MainPage.js
+++ b/examples/basic/src/MainPage.js
@@ -34,7 +34,7 @@ class MainPage extends PureComponent {
     const {
       foo, bar, onChangeFoo, onChangeBar, onChangeUrlQueryParams
     } = this.props;
-    console.log('RENDER', foo, bar);
+
     return (
       <div>
         <table>

--- a/src/__tests__/updateUrlQuery-test.js
+++ b/src/__tests__/updateUrlQuery-test.js
@@ -6,6 +6,7 @@ import {
   replaceInUrlQuery,
   pushInUrlQuery,
   updateUrlQuerySingle,
+  updateUrlQueryMulti,
 } from '../updateUrlQuery';
 
 function makeMockHistory() {
@@ -146,6 +147,52 @@ describe('pushInUrlQuery', () => {
     const location = { pathname: '/', search: '?foo=99&bar=baz' };
     const newLocation = pushInUrlQuery('foo', '123', location);
     expect(newLocation).toEqual({ pathname: '/', search: '?bar=baz&foo=123' });
+    expect(history.push).toBeCalled();
+    expect(history.replace).not.toBeCalled();
+  });
+});
+
+describe('updateUrlQueryMulti', () => {
+  it('works with replace', () => {
+    const history = makeMockHistory();
+    configureUrlQuery({ history });
+
+    const location = { pathname: '/', search: '?foo=99&bar=baz&blatt=david' };
+    const newLocation = updateUrlQueryMulti(UrlUpdateTypes.replace, { bar: 'test', foo: '123' }, location);
+    expect(newLocation).toEqual({ pathname: '/', search: '?bar=test&foo=123' });
+    expect(history.replace).toBeCalled();
+    expect(history.push).not.toBeCalled();
+  });
+
+  it('works with push', () => {
+    const history = makeMockHistory();
+    configureUrlQuery({ history });
+
+    const location = { pathname: '/', search: '?foo=99&bar=baz&blatt=david' };
+    const newLocation = updateUrlQueryMulti(UrlUpdateTypes.push, { bar: 'test', foo: '123' }, location);
+    expect(newLocation).toEqual({ pathname: '/', search: '?bar=test&foo=123' });
+    expect(history.push).toBeCalled();
+    expect(history.replace).not.toBeCalled();
+  });
+
+  it('works with replaceIn', () => {
+    const history = makeMockHistory();
+    configureUrlQuery({ history });
+
+    const location = { pathname: '/', search: '?foo=99&bar=baz&blatt=david' };
+    const newLocation = updateUrlQueryMulti(UrlUpdateTypes.replaceIn, { bar: 'test', foo: '123' }, location);
+    expect(newLocation).toEqual({ pathname: '/', search: '?bar=test&blatt=david&foo=123' });
+    expect(history.replace).toBeCalled();
+    expect(history.push).not.toBeCalled();
+  });
+
+  it('works with pushIn', () => {
+    const history = makeMockHistory();
+    configureUrlQuery({ history });
+
+    const location = { pathname: '/', search: '?foo=99&bar=baz&blatt=david' };
+    const newLocation = updateUrlQueryMulti(UrlUpdateTypes.pushIn, { bar: 'test', foo: '123' }, location);
+    expect(newLocation).toEqual({ pathname: '/', search: '?bar=test&blatt=david&foo=123' });
     expect(history.push).toBeCalled();
     expect(history.replace).not.toBeCalled();
   });

--- a/src/react/__tests__/addUrlProps-test.js
+++ b/src/react/__tests__/addUrlProps-test.js
@@ -160,6 +160,7 @@ describe('url change callbacks', () => {
 
     expect(props.onChangeFoo).toBeDefined();
     expect(props.onChangeBar).toBeDefined();
+    expect(props.onChangeUrlQueryParams).toBeDefined();
   });
 
   it('does not generate change handlers when addUrlChangeHandlers is false', () => {
@@ -175,6 +176,7 @@ describe('url change callbacks', () => {
 
     expect(props.onChangeFoo).not.toBeDefined();
     expect(props.onChangeBar).not.toBeDefined();
+    expect(props.onChangeUrlQueryParams).not.toBeDefined();
   });
 
   it('reads addUrlChangeHandlers from urlQueryConfig', () => {


### PR DESCRIPTION
- Adds in onChangeUrlQueryParams() as a prop when addChangeHandlers is true. The function takes an object mapping prop name to unencoded values and only does one update to the URL. This prevents unnecessary re-renders. An optional secondary parameter is the updateType (defaults to replaceIn).
- Adds in two new helper update functions `multiReplaceInUrlQuery` and `multiPushInUrlQuery`
- Resolves #5