### PR TITLE
Switch to using prop-types package

### DIFF
--- a/examples/basic-mapUrlToProps/package.json
+++ b/examples/basic-mapUrlToProps/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "history": "^4.2.0",
+    "prop-types": "^15.5.9",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-url-query": "1.0.0"

--- a/examples/basic-mapUrlToProps/src/MainPage.js
+++ b/examples/basic-mapUrlToProps/src/MainPage.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { decode, encode, addUrlProps, UrlQueryParamTypes, replaceInUrlQuery } from 'react-url-query';
 
 /**

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "history": "^4.2.0",
+    "prop-types": "^15.5.9",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-url-query": "1.0.0"

--- a/examples/basic/src/MainPage.js
+++ b/examples/basic/src/MainPage.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
 
 /**

--- a/examples/react-router-v2-and-redux/package.json
+++ b/examples/react-router-v2-and-redux/package.json
@@ -6,6 +6,7 @@
     "react-scripts": "^0.6.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.9",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-redux": "^4.4.5",

--- a/examples/react-router-v2-and-redux/src/MainPage.js
+++ b/examples/react-router-v2-and-redux/src/MainPage.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 

--- a/examples/react-router-v4-and-redux/package.json
+++ b/examples/react-router-v4-and-redux/package.json
@@ -6,6 +6,7 @@
     "react-scripts": "^0.6.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.9",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-redux": "^4.4.5",

--- a/examples/react-router-v4-and-redux/src/MainPage.js
+++ b/examples/react-router-v4-and-redux/src/MainPage.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 

--- a/examples/redux-with-actions/package.json
+++ b/examples/redux-with-actions/package.json
@@ -6,6 +6,7 @@
     "react-scripts": "^0.6.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.9",
     "history": "^4.2.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",

--- a/examples/redux-with-actions/src/MainPage.js
+++ b/examples/redux-with-actions/src/MainPage.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';

--- a/examples/redux/package.json
+++ b/examples/redux/package.json
@@ -6,6 +6,7 @@
     "react-scripts": "^0.6.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.9",
     "history": "^4.2.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",

--- a/examples/redux/src/MainPage.js
+++ b/examples/redux/src/MainPage.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "dependencies": {
     "loose-envify": "^1.2.0",
+    "prop-types": "^15.5.9",
     "query-string": "^4.2.3"
   },
   "npmFileMap": [

--- a/src/react/RouterToUrlQuery.js
+++ b/src/react/RouterToUrlQuery.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import configureUrlQuery from '../configureUrlQuery';
 
 /**


### PR DESCRIPTION
* Resolves #15 by updating components and examples to use the `prop-types` package instead of reading PropTypes from React