### PR TITLE
Accept empty string as a valid value in location prop

### DIFF
--- a/src/react/addUrlProps.js
+++ b/src/react/addUrlProps.js
@@ -45,7 +45,7 @@ export default function addUrlProps(options = {}) {
       let location;
 
       // react-router provides it as a prop
-      if (props.location && (props.location.query || props.location.search)) {
+      if (props.location && (props.location.query || props.location.search != null)) {
         location = props.location;
 
       // check in history


### PR DESCRIPTION
* Resolves #12 by checking explicitly if `location.search` is nully or not as opposed to truthy.