### PR TITLE
Fix bug with default decoders #28

### DIFF
--- a/src/__tests__/serialize-test.js
+++ b/src/__tests__/serialize-test.js
@@ -307,6 +307,8 @@ describe('utils', () => {
       it('decodes using default value', () => {
         const input = undefined;
         expect(decode('number', input, 94)).toBe(94);
+        expect(decode('array', 'foo_bar', [])).toEqual(['foo', 'bar']);
+        expect(decode('object', 'a-b_c-d', {})).toEqual({ a: 'b', c: 'd' });
       });
 
       it('decodes using custom function', () => {

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -372,7 +372,7 @@ export function decode(type, encodedValue, defaultValue) {
   } else if (encodedValue === undefined) {
     decodedValue = defaultValue;
   } else if (Decoders[type]) {
-    decodedValue = Decoders[type](encodedValue, defaultValue);
+    decodedValue = Decoders[type](encodedValue);
   } else {
     decodedValue = encodedValue;
   }


### PR DESCRIPTION
Was erroneously passing default value to individual decoder functions which do not expect it. Fixes #28