### PR TITLE
Exporting urlQueryDecoder, adding urlQueryEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# 1.4.0
+
+- Helpers to easily encode and decode queries based on `urlPropsQueryConfig`
+
 # 1.3.0
 
 - Support global configuration of `entrySeparator` and `keyValSeparator` serialisation properties
@@ -34,4 +38,3 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Adds in support for changing multiple query parameters at once through the `onChangeUrlQueryParams()` callback. This function is passed as a prop when `addChangeHandlers` is true. It takes an object that maps prop names to unencoded values and updates all of them at once. See the [Basic Example](https://github.com/pbeshai/react-url-query/blob/master/examples/basic/src/MainPage.js).
 - You can also make use of new helper functions `multiReplaceInUrlQuery()` and `multiPushInUrlQuery()`.
-

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -17,6 +17,8 @@
     * [Serialize](/docs/api/Serialize.md)
     * [decode](/docs/api/Serialize.md#decode), _alias of Serialize.decode for convenience_
     * [encode](/docs/api/Serialize.md#encode), _alias of Serialize.encode for convenience_
+    * [urlQueryDecoder(config)](/docs/api/urlQueryDecoder.md)
+    * [urlQueryEncoder(config)](/docs/api/urlQueryEncoder.md)
 
   * Utils
     * [subquery](/docs/api/subquery.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -15,6 +15,8 @@ React URL Query provides a number of top-level exports.
 * [Serialize](Serialize.md)
 * [decode(type, encodedValue, [defaultValue])](Serialize.md#decode), _alias of Serialize.decode for convenience_
 * [encode(type, valueToEncode)](Serialize.md#encode), _alias of Serialize.encode for convenience_
+* [urlQueryDecoder(config)](urlQueryDecoder.md)
+* [urlQueryEncoder(config)](urlQueryEncoder.md)
 
 #### Utils
 * [subquery(query, ...params)](subquery.md)

--- a/docs/api/urlQueryDecoder.md
+++ b/docs/api/urlQueryDecoder.md
@@ -1,0 +1,27 @@
+### `urlQueryDecoder(config)`
+
+A helper function to create a query decoder from [`urlPropsQueryConfig`](addUrlProps.md#urlPropsQueryConfig).
+
+
+#### Arguments
+
+1. `config` (*Object*): The `urlPropsQueryConfig` object, [see urlPropsQueryConfig for details](addUrlProps.md#urlPropsQueryConfig).
+
+#### Returns
+
+(*Function*): A function which, given an object with encoded parameters, returns the decoded equivalent. It compares against cached values to see
+if decoding is necessary or if it can reuse old values.
+
+#### Examples
+
+```js
+const urlPropsQueryConfig = {
+  foo: { type: UrlQueryParamTypes.number, queryParam: 'fooInUrl' },
+  bar: { type: UrlQueryParamTypes.string },
+};
+
+const decode = urlQueryDecoder(urlPropsQueryConfig);
+
+decode({ fooInUrl: '137', bar: 'str' });
+// === { foo: 137, bar: 'str' }
+```

--- a/docs/api/urlQueryEncoder.md
+++ b/docs/api/urlQueryEncoder.md
@@ -1,0 +1,26 @@
+### `urlQueryEncoder(config)`
+
+A helper function to create a query encoder from [`urlPropsQueryConfig`](addUrlProps.md#urlPropsQueryConfig).
+
+
+#### Arguments
+
+1. `config` (*Object*): The `urlPropsQueryConfig` object, [see urlPropsQueryConfig for details](addUrlProps.md#urlPropsQueryConfig).
+
+#### Returns
+
+(*Function*): A function which, given an object with decoded parameters, returns the encoded equivalent.
+
+#### Examples
+
+```js
+const urlPropsQueryConfig = {
+  foo: { type: UrlQueryParamTypes.number, queryParam: 'fooInUrl' },
+  bar: { type: UrlQueryParamTypes.string },
+};
+
+const encode = urlQueryEncoder(urlPropsQueryConfig);
+
+encode({ foo: 137, bar: 'str' });
+// === { fooInUrl: '137', bar: 'str' }
+```

--- a/package.json
+++ b/package.json
@@ -88,10 +88,6 @@
     "react": "^15.0 || ^16.0"
   },
   "dependencies": {
-    "gitbook-plugin-anchorjs": "^1.1.1",
-    "gitbook-plugin-edit-link": "^2.0.2",
-    "gitbook-plugin-github": "^2.0.0",
-    "gitbook-plugin-prism": "^2.3.0",
     "loose-envify": "^1.2.0",
     "prop-types": "^15.5.9",
     "query-string": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
     "react": "^15.0 || ^16.0"
   },
   "dependencies": {
+    "gitbook-plugin-anchorjs": "^1.1.1",
+    "gitbook-plugin-edit-link": "^2.0.2",
+    "gitbook-plugin-github": "^2.0.0",
+    "gitbook-plugin-prism": "^2.3.0",
     "loose-envify": "^1.2.0",
     "prop-types": "^15.5.9",
     "query-string": "^4.2.3"

--- a/src/__tests__/urlQueryDecoder-test.js
+++ b/src/__tests__/urlQueryDecoder-test.js
@@ -47,3 +47,88 @@ it('uses cached decoded values if encoded values have not changed', () => {
   expect(decode({ foo: '137_94', bar: 'bar' }).foo).toBe(decoded.foo);
   expect(decode({ foo: '137_95', bar: 'bar' }).foo).not.toBe(decoded.foo);
 });
+
+it('respects the `defaultValue` configuration', () => {
+  const urlPropsQueryConfig = {
+    foo: { type: UrlQueryParamTypes.number, defaultValue: 42 },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const decode = urlQueryDecoder(urlPropsQueryConfig);
+  const decoded = decode({ bar: 'str' });
+
+  expect(decoded).toEqual({ foo: 42, bar: 'str' });
+});
+
+it('respects the `defaultValue` configuration for the properties with named `queryParam`', () => {
+  const urlPropsQueryConfig = {
+    foo: {
+      type: UrlQueryParamTypes.number,
+      queryParam: 'fooInUrl',
+      defaultValue: 42,
+    },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const decode = urlQueryDecoder(urlPropsQueryConfig);
+  const decoded = decode({ bar: 'str' });
+
+  expect(decoded).toEqual({ foo: 42, bar: 'str' });
+});
+
+it('respects custom decoders', () => {
+  const urlPropsQueryConfig = {
+    foo: { type: value => Number(value) + 1 },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const decode = urlQueryDecoder(urlPropsQueryConfig);
+  const decoded = decode({ foo: '137', bar: 'str' });
+
+  expect(decoded).toEqual({ foo: 138, bar: 'str' });
+});
+
+it('respects custom decoders with named `queryParam`', () => {
+  const urlPropsQueryConfig = {
+    foo: { type: value => Number(value) + 1, queryParam: 'fooInUrl' },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const decode = urlQueryDecoder(urlPropsQueryConfig);
+  const decoded = decode({ fooInUrl: '137', bar: 'str' });
+
+  expect(decoded).toEqual({ foo: 138, bar: 'str' });
+});
+
+it('respects the `defaultValue` configuration with a custom decoder', () => {
+  const urlPropsQueryConfig = {
+    foo: {
+      type: (value, defaultValue) =>
+        value === '137' ? defaultValue : Number(value),
+      defaultValue: 42,
+    },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const decode = urlQueryDecoder(urlPropsQueryConfig);
+  const decoded = decode({ foo: '137', bar: 'str' });
+
+  expect(decoded).toEqual({ foo: 42, bar: 'str' });
+});
+
+it('respects the `defaultValue` configuration with a custom decoder and a named `queryParam`', () => {
+  const urlPropsQueryConfig = {
+    foo: {
+      type: (value, defaultValue) =>
+        value === '137' ? defaultValue : Number(value),
+      defaultValue: 42,
+      queryParam: 'fooInUrl',
+    },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const decode = urlQueryDecoder(urlPropsQueryConfig);
+  const decoded = decode({ fooInUrl: '137', bar: 'str' });
+
+  expect(decoded).toEqual({ foo: 42, bar: 'str' });
+});

--- a/src/__tests__/urlQueryEncoder-test.js
+++ b/src/__tests__/urlQueryEncoder-test.js
@@ -20,7 +20,7 @@ it('works with different named query param', () => {
   };
 
   const encode = urlQueryEncoder(urlPropsQueryConfig);
-  const encoded = encode({ fooInUrl: 137, bar: 'str' });
+  const encoded = encode({ foo: 137, bar: 'str' });
 
-  expect(encoded).toEqual({ foo: '137', bar: 'str' });
+  expect(encoded).toEqual({ fooInUrl: '137', bar: 'str' });
 });

--- a/src/__tests__/urlQueryEncoder-test.js
+++ b/src/__tests__/urlQueryEncoder-test.js
@@ -1,0 +1,26 @@
+import urlQueryEncoder from '../urlQueryEncoder';
+import UrlQueryParamTypes from '../UrlQueryParamTypes';
+
+it('works with basic configuration', () => {
+  const urlPropsQueryConfig = {
+    foo: { type: UrlQueryParamTypes.number },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const encode = urlQueryEncoder(urlPropsQueryConfig);
+  const encoded = encode({ foo: 137, bar: 'str' });
+
+  expect(encoded).toEqual({ foo: '137', bar: 'str' });
+});
+
+it('works with different named query param', () => {
+  const urlPropsQueryConfig = {
+    foo: { type: UrlQueryParamTypes.number, queryParam: 'fooInUrl' },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const encode = urlQueryEncoder(urlPropsQueryConfig);
+  const encoded = encode({ fooInUrl: 137, bar: 'str' });
+
+  expect(encoded).toEqual({ foo: '137', bar: 'str' });
+});

--- a/src/__tests__/urlQueryEncoder-test.js
+++ b/src/__tests__/urlQueryEncoder-test.js
@@ -24,3 +24,51 @@ it('works with different named query param', () => {
 
   expect(encoded).toEqual({ fooInUrl: '137', bar: 'str' });
 });
+
+it('works when the object to encode has got missing properties', () => {
+  const urlPropsQueryConfig = {
+    foo: { type: UrlQueryParamTypes.number, queryParam: 'fooInUrl' },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const encode = urlQueryEncoder(urlPropsQueryConfig);
+  const encoded = encode({ foo: 137 });
+
+  expect(encoded).toEqual({ fooInUrl: '137' });
+});
+
+it('works when the object to encode has got missing properies with named `queryParam`', () => {
+  const urlPropsQueryConfig = {
+    foo: { type: UrlQueryParamTypes.number, queryParam: 'fooInUrl' },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const encode = urlQueryEncoder(urlPropsQueryConfig);
+  const encoded = encode({ bar: 'str' });
+
+  expect(encoded).toEqual({ bar: 'str' });
+});
+
+it('respects custom encoders', () => {
+  const urlPropsQueryConfig = {
+    foo: { type: number => (number + 1).toString() },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const encode = urlQueryEncoder(urlPropsQueryConfig);
+  const encoded = encode({ foo: 137, bar: 'str' });
+
+  expect(encoded).toEqual({ foo: '138', bar: 'str' });
+});
+
+it('respects custom encoders with named `queryParam`', () => {
+  const urlPropsQueryConfig = {
+    foo: { type: number => (number + 1).toString(), queryParam: 'fooInUrl' },
+    bar: { type: UrlQueryParamTypes.string },
+  };
+
+  const encode = urlQueryEncoder(urlPropsQueryConfig);
+  const encoded = encode({ foo: 137, bar: 'str' });
+
+  expect(encoded).toEqual({ fooInUrl: '138', bar: 'str' });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export {
   multiReplaceInUrlQuery,
   multiPushInUrlQuery,
 } from './updateUrlQuery';
+export urlQueryDecoder from './urlQueryDecoder';
 export UrlQueryParamTypes from './UrlQueryParamTypes';
 export UrlUpdateTypes from './UrlUpdateTypes';
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export {
   multiPushInUrlQuery,
 } from './updateUrlQuery';
 export urlQueryDecoder from './urlQueryDecoder';
+export urlQueryEncoder from './urlQueryEncoder';
 export UrlQueryParamTypes from './UrlQueryParamTypes';
 export UrlUpdateTypes from './UrlUpdateTypes';
 

--- a/src/urlQueryEncoder.js
+++ b/src/urlQueryEncoder.js
@@ -6,7 +6,7 @@ import { encode } from './serialize';
  *
  * @param {Object} query The query object (typically from props.location.query)
  *
- * @return {Object} the decoded values `{ key: decodedValue, ... }`
+ * @return {Object} the encoded values `{ key: encodedValue, ... }`
  */
 export default function urlQueryEncoder(config) {
   return function encodeQuery(query) {

--- a/src/urlQueryEncoder.js
+++ b/src/urlQueryEncoder.js
@@ -15,11 +15,11 @@ export default function urlQueryEncoder(config) {
       const keyConfig = config[key];
       // read from the URL key if provided, otherwise use the key
       const { queryParam = key } = keyConfig;
-      const decodedValue = query[queryParam];
+      const decodedValue = query[key];
 
       const encodedValue = encode(keyConfig.type, decodedValue);
 
-      encoded[key] = encodedValue;
+      encoded[queryParam] = encodedValue;
       return encoded;
     }, {});
 

--- a/src/urlQueryEncoder.js
+++ b/src/urlQueryEncoder.js
@@ -1,5 +1,13 @@
 import { encode } from './serialize';
 
+/**
+ * Encodes a query based on the config. Similarly to `encode`, it does not respect the `defaultValue`
+ * field, so any missing values must be specified explicitly.
+ *
+ * @param {Object} query The query object (typically from props.location.query)
+ *
+ * @return {Object} the decoded values `{ key: decodedValue, ... }`
+ */
 export default function urlQueryEncoder(config) {
   return function encodeQuery(query) {
     // encode the query

--- a/src/urlQueryEncoder.js
+++ b/src/urlQueryEncoder.js
@@ -9,10 +9,7 @@ export default function urlQueryEncoder(config) {
       const { queryParam = key } = keyConfig;
       const decodedValue = query[queryParam];
 
-      const encodedValue = encode(
-        keyConfig.type,
-        decodedValue
-      );
+      const encodedValue = encode(keyConfig.type, decodedValue);
 
       encoded[key] = encodedValue;
       return encoded;

--- a/src/urlQueryEncoder.js
+++ b/src/urlQueryEncoder.js
@@ -1,0 +1,23 @@
+import { encode } from './serialize';
+
+export default function urlQueryEncoder(config) {
+  return function encodeQuery(query) {
+    // encode the query
+    const encodedQuery = Object.keys(config).reduce((encoded, key) => {
+      const keyConfig = config[key];
+      // read from the URL key if provided, otherwise use the key
+      const { queryParam = key } = keyConfig;
+      const decodedValue = query[queryParam];
+
+      const encodedValue = encode(
+        keyConfig.type,
+        decodedValue
+      );
+
+      encoded[key] = encodedValue;
+      return encoded;
+    }, {});
+
+    return encodedQuery;
+  };
+}


### PR DESCRIPTION
`addUrlProps` HOC makes you create a handy configuration, but as of now, this config cannot be reused with another parts of the library.

This PR does 2 things to make this config more useful:
1. exports `urlQueryDecoder`.
2. adds the `urlQueryEncoder` helper.