### PR TITLE
better connected to redux state using baz demo

### DIFF
--- a/examples/react-router-v2-and-redux/src/MainPage.js
+++ b/examples/react-router-v2-and-redux/src/MainPage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
-import { addUrlProps, UrlQueryParamTypes, subquery } from 'react-url-query';
+import { addUrlProps, UrlQueryParamTypes, UrlUpdateTypes, subquery } from 'react-url-query';
 import { changeBaz } from './state/actions';
 
 /**
@@ -28,7 +28,7 @@ const urlPropsQueryConfig = {
   arr: { type: UrlQueryParamTypes.array },
   bar: { type: UrlQueryParamTypes.string, validate: bar => bar && bar.length < 6 },
   foo: { type: UrlQueryParamTypes.number, queryParam: 'fooInUrl' },
-  baz: { type: UrlQueryParamTypes.string, queryParam: 'baz' },
+  baz: { type: UrlQueryParamTypes.string, updateType: UrlUpdateTypes.pushIn, queryParam: 'baz' },
   custom: { type: customType },
 }
 
@@ -37,6 +37,7 @@ const urlPropsQueryConfig = {
  * the `baz` prop in MainPage. Used via the higher-order component `connect`.
  */
 function mapStateToProps(state, props) {
+    console.log(state.app);
   return {
     baz: state.app.baz,
   };
@@ -69,6 +70,17 @@ class MainPage extends PureComponent {
     baz: 'baz',
     custom: 'custom',
     foo: 123,
+  }
+
+  /**
+   * When copy the URL to share, the state can be updated here and related
+   * components will also be updated;
+   */
+  componentWillMount() {
+      const query = this.props.location.query;
+      if(!!query.baz) {
+          this.updateBaz(query.baz);
+      }
   }
 
   /**
@@ -175,7 +187,7 @@ class MainPage extends PureComponent {
                   Change baz
                 </button>
                 <span>  the value of baz: </span>
-                <input value={this.props.baz} onChange={this.handleBazChange}/>
+                <input value={baz} onChange={this.handleBazChange}/>
               </td>
             </tr>
           </tbody>

--- a/examples/react-router-v2-and-redux/src/MainPage.js
+++ b/examples/react-router-v2-and-redux/src/MainPage.js
@@ -28,7 +28,8 @@ const urlPropsQueryConfig = {
   arr: { type: UrlQueryParamTypes.array },
   bar: { type: UrlQueryParamTypes.string, validate: bar => bar && bar.length < 6 },
   foo: { type: UrlQueryParamTypes.number, queryParam: 'fooInUrl' },
-  custom: { type: customType }
+  baz: { type: UrlQueryParamTypes.string, queryParam: 'baz' },
+  custom: { type: customType },
 }
 
 /**
@@ -41,14 +42,6 @@ function mapStateToProps(state, props) {
   };
 }
 
-/**
- * Standard react-redux mapDispatchToProps
- */
-function mapDispatchToProps(dispatch) {
-  return {
-    onChangeBaz: (baz) => dispatch(changeBaz(baz)),
-  };
-}
 
 /**
  * The MainPage container. Note that none of the code within this component
@@ -95,9 +88,19 @@ class MainPage extends PureComponent {
     }
   }
 
+  handleBazChange = (e) => {
+    const newBaz = e.target.value;
+    this.updateBaz(newBaz);
+  }
+
+  updateBaz = (baz) => {
+    this.props.onChangeBaz(baz);
+    this.props.dispatch(changeBaz(baz));
+  }
+
   render() {
     const { arr, foo, bar, baz, custom, word, location, onChangeArr,
-      onChangeBar, onChangeBaz, onChangeFoo, onChangeCustom } = this.props;
+      onChangeBar, onChangeFoo, onChangeCustom } = this.props;
 
     return (
       <div>
@@ -165,9 +168,14 @@ class MainPage extends PureComponent {
               <td>{baz}</td>
               <td>(redux state)</td>
               <td>
-                <button onClick={() => onChangeBaz(Math.random().toString(32).substring(10))}>
+                <button onClick={() => {
+                    let baz = Math.random().toString(32).substring(10);
+                    this.updateBaz(baz);
+                }}>
                   Change baz
                 </button>
+                <span>  the value of baz: </span>
+                <input value={this.props.baz} onChange={this.handleBazChange}/>
               </td>
             </tr>
           </tbody>
@@ -182,4 +190,4 @@ class MainPage extends PureComponent {
  * to props for MainPage. In this case the mapping happens automatically by
  * first decoding the URL query parameters based on the urlPropsQueryConfig.
  */
-export default addUrlProps({ urlPropsQueryConfig })(connect(mapStateToProps, mapDispatchToProps)(MainPage));
+export default addUrlProps({ urlPropsQueryConfig })(connect(mapStateToProps)(MainPage));


### PR DESCRIPTION
mapDispatchToProps is not quite appropriate in this demo, you could check this [answer](https://stackoverflow.com/questions/39419237/what-is-mapdispatchtoprops#answer-40068198) for more details. 

Besides, I think binding URL, state and component all together is quite essential to be presented for redux. So basically I bond them altogether here to meet the requirement from this [post](https://stackoverflow.com/questions/36596996/how-to-sync-redux-state-and-url-query-params).