### PR TITLE
Support multiPush/ReplaceIn for redux-with-actions apps

### DIFF
--- a/docs/api/multiPushInUrlQueryWithAction.md
+++ b/docs/api/multiPushInUrlQueryWithAction.md
@@ -1,0 +1,49 @@
+### `multiPushInUrlQueryFromAction(action, [location])`
+
+A helper function for when you want to use redux `dispatch` to handle your URL updating actions, an optional way of combining Redux with React URL Query. It expects the action to have the form:
+
+```
+{
+  payload: {
+    encodedQuery: {
+      queryParamName: encodedValue,
+      ...
+    }
+  }
+  ...
+}
+```
+
+This function is typically only useful when using your own urlReducer, as shown in [this example](https://github.com/pbeshai/react-url-query/tree/master/examples/redux-with-actions).
+
+Uses push to change the URL, which means the new state will be pushed on to the history stack, so the back button will be able to return you to the previous state.
+
+#### Arguments
+
+1. `action` (*Object*): An action, typically from [`urlMultiPushInAction`](urlMultiPushInAction.md). Shape described above.
+1. [`location`] (*Object*): The location from which the current URL state should be read. If not provided, `location` is read from the configured `history` or the `window`.
+
+#### Returns
+
+(*void*): It does not return anything.
+
+
+#### Examples
+
+```js
+// create an action creator
+const changeFoo = urlMultiPushInAction(
+  'CHANGE_FOO',
+  (newQuery) => ({
+    foo: encode(UrlQueryParamTypes.number, newQuery.foo),
+  })
+);
+
+// call an action creator to get an action
+const action = changeFoo({foo: 94});
+
+// typically in a reducer, call this helper to update the URL
+// e.g. URL was /page?foo=123&bar=baz
+multiPushInUrlQueryFromAction(action)
+// e.g. URL now is /page?foo=94&bar=baz
+```

--- a/docs/api/multiReplaceInUrlQueryFromAction.md
+++ b/docs/api/multiReplaceInUrlQueryFromAction.md
@@ -1,0 +1,49 @@
+### `multiReplaceInUrlQueryFromAction(action, [location])`
+
+A helper function for when you want to use redux `dispatch` to handle your URL updating actions, an optional way of combining Redux with React URL Query. It expects the action to have the form:
+
+```
+{
+  payload: {
+    encodedQuery: {
+      queryParamName: encodedValue,
+      ...
+    }
+  }
+  ...
+}
+```
+
+This function is typically only useful when using your own urlReducer, as shown in [this example](https://github.com/pbeshai/react-url-query/tree/master/examples/redux-with-actions).
+
+Uses replace to change the URL, which means nothing gets pushed on to the history stack, so the back button will not be able to return you to the previous state.
+
+#### Arguments
+
+1. `action` (*Object*): An action, typically from [`urlReplaceInAction`](urlReplaceInAction.md). Shape described above.
+1. [`location`] (*Object*): The location from which the current URL state should be read. If not provided, `location` is read from the configured `history` or the `window`.
+
+#### Returns
+
+(*void*): It does not return anything.
+
+
+#### Examples
+
+```js
+// create an action creator
+const changeFoo = urlMultiReplaceInAction(
+  'CHANGE_FOO',
+  (newQuery) => ({
+    foo: encode(UrlQueryParamTypes.number, newQuery.foo),
+  })
+);
+
+// call an action creator to get an action
+const action = changeFoo({foo: 94});
+
+// typically in a reducer, call this helper to update the URL
+// e.g. URL was /page?foo=123&bar=baz
+multiReplaceInUrlQueryFromAction(action)
+// e.g. URL now is /page?foo=94&bar=baz
+```

--- a/docs/api/urlMultiPushInAction.md
+++ b/docs/api/urlMultiPushInAction.md
@@ -1,0 +1,55 @@
+### `urlMultiPushInAction(actionType, [encodeQuery])`
+
+A helper function to create action creators that can create actions interpretable by [urlQueryMiddleware](urlQueryMiddleware.md) and [urlQueryReducer](urlQueryReducer.md) to push a change to several query parameters into the URL, adding an entry to the history stack. The standard format of an action produced by the action creators this function creates is:
+
+```js
+{
+  type: actionType,
+  meta: {
+    updateType: UrlUpdateTypes.multiPushIn,
+    urlQuery: true
+  },
+  payload: {
+    encodedQuery: Object,
+    decodedQuery: Object,
+  }
+}
+```
+
+
+#### Arguments
+
+1. `actionType` (*String*): The standard redux action type, maps to `type` in the action.
+1. [`encodeQuery`] (*Function*): A function that takes in a query object and maps it to an *Object* where the keys represent query parameters and the values represent encoded *String* values.
+
+#### Returns
+
+(*Function*): An action creator that will produce an action that is recognizable by [urlQueryMiddleware](urlQueryMiddleware.md) and [urlQueryReducer](urlQueryReducer.md).
+
+#### Remarks
+
+* The default [urlQueryReducer](urlQueryReducer.md) provided by React URL Query interprets the `updateType` property in the meta of the action to update the URL accordingly. If you are not using it, you'll need to do so manually.
+
+#### Examples
+
+```js
+const changeFooBar = urlMultiPushInAction(
+  'CHANGE_FOO_BAR',
+  query => ({ foo: String(query.foo), bar: query.bar })
+);
+dispatch(changeFooBar({ foo: 137, bar: 'baz' }));
+/*
+dispatches action of form:
+  {
+    type: 'CHANGE_FOO_BAR',
+    meta: {
+      urlQuery: true,
+      updateType: UrlUpdateTypes.multiPushIn
+    },
+    payload: {
+      encodedQuery: { foo: '137', bar: 'baz' },
+      decodedQuery: { foo: 137, bar: 'baz' }
+    }
+  }
+*/
+```

--- a/docs/api/urlMultiReplaceInAction.md
+++ b/docs/api/urlMultiReplaceInAction.md
@@ -1,0 +1,55 @@
+### `urlMultiReplaceInAction(actionType, [encodeQuery])`
+
+A helper function to create action creators that can create actions interpretable by [urlQueryMiddleware](urlQueryMiddleware.md) and [urlQueryReducer](urlQueryReducer.md) to set new query parameters into the URL, replacing what was there previously without adding an entry to the history stack. The standard format of an action produced by the action creators this function creates is:
+
+```js
+{
+  type: actionType,
+  meta: {
+    updateType: UrlUpdateTypes.multiReplaceIn,
+    urlQuery: true
+  },
+  payload: {
+    encodedQuery: Object,
+    decodedQuery: Object,
+  }
+}
+```
+
+
+#### Arguments
+
+1. `actionType` (*String*): The standard redux action type, maps to `type` in the action.
+1. [`encodeQuery`] (*Function*): A function that takes in a query object and maps it to an *Object* where the keys represent query parameters and the values represent encoded *String* values.
+
+#### Returns
+
+(*Function*): An action creator that will produce an action that is recognizable by [urlQueryMiddleware](urlQueryMiddleware.md) and [urlQueryReducer](urlQueryReducer.md).
+
+#### Remarks
+
+* The default [urlQueryReducer](urlQueryReducer.md) provided by React URL Query interprets the `updateType` property in the meta of the action to update the URL accordingly. If you are not using it, you'll need to do so manually.
+
+#### Examples
+
+```js
+const changeFooBar = urlMultiReplaceInAction(
+  'CHANGE_FOO_BAR',
+  query => ({ foo: String(query.foo), bar: query.bar })
+);
+dispatch(changeFooBar({ foo: 137, bar: 'baz' }));
+/*
+dispatches action of form:
+  {
+    type: 'CHANGE_FOO_BAR',
+    meta: {
+      urlQuery: true,
+      updateType: UrlUpdateTypes.multiReplaceIn
+    },
+    payload: {
+      encodedQuery: { foo: '137', bar: 'baz' },
+      decodedQuery: { foo: 137, bar: 'baz' }
+    }
+  }
+*/
+```

--- a/src/UrlUpdateTypes.js
+++ b/src/UrlUpdateTypes.js
@@ -1,8 +1,10 @@
 const UrlUpdateTypes = {
   replace: 'replace',
   replaceIn: 'replaceIn',
+  multiReplaceIn: 'multiReplaceIn',
   push: 'push',
   pushIn: 'pushIn',
+  multiPushIn: 'multiPushIn',
 };
 
 export default UrlUpdateTypes;

--- a/src/__tests__/updateUrlQuery-test.js
+++ b/src/__tests__/updateUrlQuery-test.js
@@ -5,6 +5,8 @@ import {
   pushUrlQuery,
   replaceInUrlQuery,
   pushInUrlQuery,
+  multiReplaceInUrlQuery,
+  multiPushInUrlQuery,
   updateUrlQuerySingle,
   updateUrlQueryMulti,
 } from '../updateUrlQuery';
@@ -108,6 +110,19 @@ describe('pushUrlQuery', () => {
   });
 });
 
+describe('multiReplaceInUrlQuery', () => {
+  it('replaces the values for the specified params in the query and calls replace in history', () => {
+    const history = makeMockHistory();
+    configureUrlQuery({ history });
+
+    const location = { pathname: '/', search: '?foo=99&bar=baz&ack=blech' };
+    const newLocation = multiReplaceInUrlQuery({foo: '123', bar: null}, location);
+    expect(newLocation).toEqual({ pathname: '/', search: '?ack=blech&foo=123' });
+    expect(history.replace).toBeCalled();
+    expect(history.push).not.toBeCalled();
+  });
+});
+
 describe('replaceInUrlQuery', () => {
   it('replaces the value for the specified param in the query and calls replace in history', () => {
     const history = makeMockHistory();
@@ -163,6 +178,19 @@ describe('replaceInUrlQuery', () => {
   //   expect(history.replace).toBeCalled();
   //   expect(history.push).not.toBeCalled();
   // });
+});
+
+describe('multiPushInUrlQuery', () => {
+  it('replaces the values for the specified params in the query and calls push in history', () => {
+    const history = makeMockHistory();
+    configureUrlQuery({ history });
+
+    const location = { pathname: '/', search: '?foo=99&bar=baz&ack=blech' };
+    const newLocation = multiPushInUrlQuery({foo: '123', bar: null}, location);
+    expect(newLocation).toEqual({ pathname: '/', search: '?ack=blech&foo=123' });
+    expect(history.push).toBeCalled();
+    expect(history.replace).not.toBeCalled();
+  });
 });
 
 describe('pushInUrlQuery', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -22,14 +22,18 @@ export RouterToUrlQuery from './react/RouterToUrlQuery';
 export {
   replaceInUrlQueryFromAction,
   replaceUrlQueryFromAction,
+  multiReplaceInUrlQueryFromAction,
   pushInUrlQueryFromAction,
   pushUrlQueryFromAction,
+  multiPushInUrlQueryFromAction,
 } from './redux/updateUrlQueryFromAction';
 export urlAction, {
   urlReplaceAction,
   urlPushAction,
   urlReplaceInAction,
   urlPushInAction,
+  urlMultiReplaceInAction,
+  urlMultiPushInAction,
 } from './redux/urlAction';
 export urlQueryMiddleware from './redux/urlQueryMiddleware';
 export urlQueryReducer from './redux/urlQueryReducer';

--- a/src/redux/__tests__/updateUrlQueryFromAction-test.js
+++ b/src/redux/__tests__/updateUrlQueryFromAction-test.js
@@ -1,15 +1,19 @@
 import {
   replaceInUrlQueryFromAction,
   replaceUrlQueryFromAction,
+  multiReplaceInUrlQueryFromAction,
   pushInUrlQueryFromAction,
   pushUrlQueryFromAction,
+  multiPushInUrlQueryFromAction,
 } from '../updateUrlQueryFromAction';
 
 import {
   replaceInUrlQuery,
   replaceUrlQuery,
+  multiReplaceInUrlQuery,
   pushInUrlQuery,
   pushUrlQuery,
+  multiPushInUrlQuery,
 } from '../../updateUrlQuery';
 
 // mock this module so we can test if it as called with correct args
@@ -29,6 +33,22 @@ it('pushInUrlQueryFromAction extracts correct args from action', () => {
     'location'
   );
   expect(pushInUrlQuery).toBeCalledWith('foo', '94', 'location');
+});
+
+it('multiReplaceInUrlQueryFromAction extracts correct args from action', () => {
+  multiReplaceInUrlQueryFromAction(
+    { payload: { encodedQuery: { foo: '94' } } },
+    'location'
+  );
+  expect(multiReplaceInUrlQuery).toBeCalledWith({ foo: '94' }, 'location');
+});
+
+it('multiPushInUrlQueryFromAction extracts correct args from action', () => {
+  multiPushInUrlQueryFromAction(
+    { payload: { encodedQuery: { foo: '94' } } },
+    'location'
+  );
+  expect(multiPushInUrlQuery).toBeCalledWith({ foo: '94' }, 'location');
 });
 
 it('replaceUrlQueryFromAction extracts correct args from action', () => {

--- a/src/redux/__tests__/urlAction-test.js
+++ b/src/redux/__tests__/urlAction-test.js
@@ -2,6 +2,8 @@ import urlAction, {
   urlUpdateAction,
   urlReplaceAction,
   urlPushAction,
+  urlMultiReplaceInAction,
+  urlMultiPushInAction,
   urlUpdateInAction,
   urlReplaceInAction,
   urlPushInAction,
@@ -120,6 +122,44 @@ it('urlPushAction creates the proper action creator -> action', () => {
     meta: {
       urlQuery: true,
       updateType: UrlUpdateTypes.push,
+    },
+    payload: {
+      encodedQuery: { foo: '137', bar: '1' },
+      decodedQuery: { foo: 137 },
+    },
+  });
+});
+
+it('urlMultiReplaceInAction creates the proper action creator -> action', () => {
+  const creator = urlMultiReplaceInAction('TEST_ACTION', query => ({
+    foo: String(query.foo),
+    bar: '1',
+  }));
+  const action = creator({ foo: 137 });
+  expect(action).toEqual({
+    type: 'TEST_ACTION',
+    meta: {
+      urlQuery: true,
+      updateType: UrlUpdateTypes.multiReplaceIn,
+    },
+    payload: {
+      encodedQuery: { foo: '137', bar: '1' },
+      decodedQuery: { foo: 137 },
+    },
+  });
+});
+
+it('urlMultiPushInAction creates the proper action creator -> action', () => {
+  const creator = urlMultiPushInAction('TEST_ACTION', query => ({
+    foo: String(query.foo),
+    bar: '1',
+  }));
+  const action = creator({ foo: 137 });
+  expect(action).toEqual({
+    type: 'TEST_ACTION',
+    meta: {
+      urlQuery: true,
+      updateType: UrlUpdateTypes.multiPushIn,
     },
     payload: {
       encodedQuery: { foo: '137', bar: '1' },

--- a/src/redux/__tests__/urlQueryReducer-test.js
+++ b/src/redux/__tests__/urlQueryReducer-test.js
@@ -4,8 +4,10 @@ import UrlUpdateTypes from '../../UrlUpdateTypes';
 import {
   replaceInUrlQueryFromAction,
   replaceUrlQueryFromAction,
+  multiReplaceInUrlQueryFromAction,
   pushInUrlQueryFromAction,
   pushUrlQueryFromAction,
+  multiPushInUrlQueryFromAction,
 } from '../updateUrlQueryFromAction';
 
 // mock this module so we can test if it as called with correct args
@@ -33,6 +35,18 @@ it('reduces push', () => {
   const action = { meta: { updateType: UrlUpdateTypes.push } };
   urlQueryReducer(action, 'location');
   expect(pushUrlQueryFromAction).toBeCalledWith(action, 'location');
+});
+
+it('reduces multiReplaceIn', () => {
+  const action = { meta: { updateType: UrlUpdateTypes.multiReplaceIn } };
+  urlQueryReducer(action, 'location');
+  expect(multiReplaceInUrlQueryFromAction).toBeCalledWith(action, 'location');
+});
+
+it('reduces multiPushIn', () => {
+  const action = { meta: { updateType: UrlUpdateTypes.multiPushIn } };
+  urlQueryReducer(action, 'location');
+  expect(multiPushInUrlQueryFromAction).toBeCalledWith(action, 'location');
 });
 
 it('does not fail with nully action', () => {

--- a/src/redux/updateUrlQueryFromAction.js
+++ b/src/redux/updateUrlQueryFromAction.js
@@ -1,8 +1,10 @@
 import {
   replaceInUrlQuery,
   replaceUrlQuery,
+  multiReplaceInUrlQuery,
   pushInUrlQuery,
   pushUrlQuery,
+  multiPushInUrlQuery,
 } from '../updateUrlQuery';
 
 export function replaceUrlQueryFromAction(action, location) {
@@ -23,4 +25,14 @@ export function replaceInUrlQueryFromAction(action, location) {
 export function pushInUrlQueryFromAction(action, location) {
   const { queryParam, encodedValue } = action.payload;
   pushInUrlQuery(queryParam, encodedValue, location);
+}
+
+export function multiReplaceInUrlQueryFromAction(action, location) {
+  const { encodedQuery } = action.payload;
+  multiReplaceInUrlQuery(encodedQuery, location);
+}
+
+export function multiPushInUrlQueryFromAction(action, location) {
+  const { encodedQuery } = action.payload;
+  multiPushInUrlQuery(encodedQuery, location);
 }

--- a/src/redux/urlAction.js
+++ b/src/redux/urlAction.js
@@ -32,8 +32,23 @@ export default function urlAction(
  * Helper function for creating URL action creators
  *
  * For example in your actions.js file:
- * export const changeFoo = urlAction('CHANGE_FOO', 'replace');
  *
+ * export const changeFoo = urlUpdateAction(
+ *   'CHANGE_MANY',
+ *   (newQuery) => ({
+ *     fooInUrl: encode(UrlQueryParamTypes.number, newQuery.foo),
+ *     bar: 'par',
+ *     arr: encode(UrlQueryParamTypes.array, ['T', 'Y']),
+ *   }),
+ *   'replace');
+ *
+ * The second parameter should be an encoder function that takes a decodedQuery
+ * and returns an encodedQuery,
+ * encoding each value in the decodedQuery object.
+ * You need this because when using Redux Actions,
+ * urlPropsQueryConfig is only used for decoding;
+ * you have to implement the encoding here.
+ * Also see changeMany [in the examples](https://github.com/pbeshai/react-url-query/tree/master/examples/redux-with-actions/src/state/actions.js).
  */
 export function urlUpdateAction(
   actionType,
@@ -58,11 +73,19 @@ export function urlPushAction(actionType, encodeQuery) {
   return urlUpdateAction(actionType, encodeQuery, UrlUpdateTypes.push);
 }
 
+export function urlMultiReplaceInAction(actionType, encodeQuery) {
+  return urlUpdateAction(actionType, encodeQuery, UrlUpdateTypes.multiReplaceIn);
+}
+
+export function urlMultiPushInAction(actionType, encodeQuery) {
+  return urlUpdateAction(actionType, encodeQuery, UrlUpdateTypes.multiPushIn);
+}
+
 /**
  * Helper function for creating URL action creators
  *
  * For example in your actions.js file:
- * export const changeFoo = urlInAction('CHANGE_FOO', 'foo', 'number', 'replaceIn');
+ * export const changeFoo = urlUpdateInAction('CHANGE_FOO', 'foo', 'number', 'replaceIn');
  *
  */
 export function urlUpdateInAction(

--- a/src/redux/urlQueryReducer.js
+++ b/src/redux/urlQueryReducer.js
@@ -1,8 +1,10 @@
 import {
   replaceInUrlQueryFromAction,
   replaceUrlQueryFromAction,
+  multiReplaceInUrlQueryFromAction,
   pushInUrlQueryFromAction,
   pushUrlQueryFromAction,
+  multiPushInUrlQueryFromAction,
 } from './updateUrlQueryFromAction';
 import UrlUpdateTypes from '../UrlUpdateTypes';
 
@@ -21,10 +23,14 @@ export default function urlQueryReducer(action, location) {
       return replaceInUrlQueryFromAction(action, location);
     case UrlUpdateTypes.replace:
       return replaceUrlQueryFromAction(action, location);
+    case UrlUpdateTypes.multiReplaceIn:
+      return multiReplaceInUrlQueryFromAction(action, location);
     case UrlUpdateTypes.pushIn:
       return pushInUrlQueryFromAction(action, location);
     case UrlUpdateTypes.push:
       return pushUrlQueryFromAction(action, location);
+    case UrlUpdateTypes.multiPushIn:
+      return multiPushInUrlQueryFromAction(action, location);
     default:
       break;
   }


### PR DESCRIPTION
When working with Redux actions, there are no built-in functions to help build, dispatch, and reduce updates to multiple URL query params (without losing the others). This patch adds functions, tests, and documentation for `multiPushIn` and `multiReplaceIn`.