### PR TITLE
Corrects docs where PropTypes was pulled from React. Closes #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ npm install --save react-url-query
 A [number of examples](https://pbeshai.github.io/react-url-query/docs/Examples.html) have been created demonstrating a variety of methods of using the library with different technologies. Here is the most basic form of using it in a component:
 
 ```js
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
 
 /**

--- a/docs/api/addUrlProps.md
+++ b/docs/api/addUrlProps.md
@@ -61,7 +61,8 @@ A React component class
 ##### Usage with `urlPropsQueryConfig`
 
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
 
 /**


### PR DESCRIPTION
Docs will need to be published after this commit is merged.